### PR TITLE
Feat: display top 10 related papers

### DIFF
--- a/src/routes/HierarchicalViz.svelte
+++ b/src/routes/HierarchicalViz.svelte
@@ -12,7 +12,7 @@
   import * as d3 from "d3";
   import type { Data } from "../types/type.ts";
 
-  export let selectedPaper: Data | null;
+  export let selectedPaper: Data;
   export let data: Data[];
 
   // Color scale based on 'cluster' column, 10 colors

--- a/src/routes/PaperInfo.svelte
+++ b/src/routes/PaperInfo.svelte
@@ -11,7 +11,7 @@
 
   //   filteredData, selectedPaper are props from parent
   export let filteredData: Data[];
-  export let selectedPaper: Data | null;
+  export let selectedPaper: Data;
 
 
   let rowRefs = [] as HTMLTableRowElement[];

--- a/src/routes/Visualization.svelte
+++ b/src/routes/Visualization.svelte
@@ -408,6 +408,10 @@
       })
       .on("mouseover", function (event, d) {
         highlight(d);
+        tooltip.style("display", "block").style("opacity", 1);
+      })
+      .on("mousemove", function (event, d) {
+        // enlarge that dot
         d3.selectAll(".dot")
           .transition()
           .duration(100)
@@ -429,9 +433,7 @@
           .attr("r", 12)
           .attr("stroke-width", 2)
           .attr("stroke", "black");
-        tooltip.style("display", "block").style("opacity", 1);
-      })
-      .on("mousemove", function (event, d) {
+
         tooltip
           .html(
             "<b>" +

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -17,6 +17,7 @@ export type Data = {
     area_of_focus: string;
     gs_link: string;
     author_id: string;
+    distance: number;
 };
 
 export type SelectableColumn = "cluster" | "faculty" | "department" | "focus_tag";

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -17,7 +17,8 @@ export type Data = {
     area_of_focus: string;
     gs_link: string;
     author_id: string;
-    distance: number;
+    embeddings: number[];
+    cosine_similarity: number;
 };
 
 export type SelectableColumn = "cluster" | "faculty" | "department" | "focus_tag";


### PR DESCRIPTION
When a node is selected, display its top 10 related nodes with forceLink effect to reduce overlapping:

<img width="827" alt="Screen Shot 2024-02-25 at 12 27 08 AM" src="https://github.com/ryanyen2/waterloo-ai-institute/assets/93347757/7a27b8d0-43af-4294-9254-a03a26bed4dd">
